### PR TITLE
Add new fields to DOM_SENSOR table in STATE_DB for C_CMIS

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -19,6 +19,7 @@ try:
     import datetime
     import subprocess
     import argparse
+    import re
 
     from sonic_py_common import daemon_base, device_info, logger
     from sonic_py_common import multi_asic
@@ -216,33 +217,18 @@ def _wrapper_get_sfp_error_description(physical_port):
 # Remove unnecessary unit from the raw data
 
 def beautify_dom_info_dict(dom_info_dict, physical_port):
-    dom_info_dict['temperature'] = strip_unit_and_beautify(dom_info_dict['temperature'], TEMP_UNIT)
-    dom_info_dict['voltage'] = strip_unit_and_beautify(dom_info_dict['voltage'], VOLT_UNIT)
-    dom_info_dict['rx1power'] = strip_unit_and_beautify(dom_info_dict['rx1power'], POWER_UNIT)
-    dom_info_dict['rx2power'] = strip_unit_and_beautify(dom_info_dict['rx2power'], POWER_UNIT)
-    dom_info_dict['rx3power'] = strip_unit_and_beautify(dom_info_dict['rx3power'], POWER_UNIT)
-    dom_info_dict['rx4power'] = strip_unit_and_beautify(dom_info_dict['rx4power'], POWER_UNIT)
-    dom_info_dict['tx1bias'] = strip_unit_and_beautify(dom_info_dict['tx1bias'], BIAS_UNIT)
-    dom_info_dict['tx2bias'] = strip_unit_and_beautify(dom_info_dict['tx2bias'], BIAS_UNIT)
-    dom_info_dict['tx3bias'] = strip_unit_and_beautify(dom_info_dict['tx3bias'], BIAS_UNIT)
-    dom_info_dict['tx4bias'] = strip_unit_and_beautify(dom_info_dict['tx4bias'], BIAS_UNIT)
-    dom_info_dict['tx1power'] = strip_unit_and_beautify(dom_info_dict['tx1power'], POWER_UNIT)
-    dom_info_dict['tx2power'] = strip_unit_and_beautify(dom_info_dict['tx2power'], POWER_UNIT)
-    dom_info_dict['tx3power'] = strip_unit_and_beautify(dom_info_dict['tx3power'], POWER_UNIT)
-    dom_info_dict['tx4power'] = strip_unit_and_beautify(dom_info_dict['tx4power'], POWER_UNIT)
-    if 'rx5power' in dom_info_dict:
-        dom_info_dict['rx5power'] = strip_unit_and_beautify(dom_info_dict['rx5power'], POWER_UNIT)
-        dom_info_dict['rx6power'] = strip_unit_and_beautify(dom_info_dict['rx6power'], POWER_UNIT)
-        dom_info_dict['rx7power'] = strip_unit_and_beautify(dom_info_dict['rx7power'], POWER_UNIT)
-        dom_info_dict['rx8power'] = strip_unit_and_beautify(dom_info_dict['rx8power'], POWER_UNIT)
-        dom_info_dict['tx5bias'] = strip_unit_and_beautify(dom_info_dict['tx5bias'], BIAS_UNIT)
-        dom_info_dict['tx6bias'] = strip_unit_and_beautify(dom_info_dict['tx6bias'], BIAS_UNIT)
-        dom_info_dict['tx7bias'] = strip_unit_and_beautify(dom_info_dict['tx7bias'], BIAS_UNIT)
-        dom_info_dict['tx8bias'] = strip_unit_and_beautify(dom_info_dict['tx8bias'], BIAS_UNIT)
-        dom_info_dict['tx5power'] = strip_unit_and_beautify(dom_info_dict['tx5power'], POWER_UNIT)
-        dom_info_dict['tx6power'] = strip_unit_and_beautify(dom_info_dict['tx6power'], POWER_UNIT)
-        dom_info_dict['tx7power'] = strip_unit_and_beautify(dom_info_dict['tx7power'], POWER_UNIT)
-        dom_info_dict['tx8power'] = strip_unit_and_beautify(dom_info_dict['tx8power'], POWER_UNIT)
+    for k, v in dom_info_dict.items():
+        if k == 'temperature':
+            dom_info_dict[k] = strip_unit_and_beautify(v, TEMP_UNIT)
+        elif k == 'voltage':
+            dom_info_dict[k] = strip_unit_and_beautify(v, VOLT_UNIT)
+        elif re.match('^(tx|rx)[1-8]power$', k):
+            dom_info_dict[k] = strip_unit_and_beautify(v, POWER_UNIT)
+        elif re.match('^(tx|rx)[1-8]bias$', k):
+            dom_info_dict[k] = strip_unit_and_beautify(v, BIAS_UNIT)
+        elif type(v) is not str:
+            # For all the other keys:
+            dom_info_dict[k] = str(v)
 
 
 def beautify_dom_threshold_info_dict(dom_info_dict):
@@ -507,53 +493,7 @@ def post_port_dom_info_to_db(logical_port_name, port_mapping, table, stop_event=
                     dom_info_cache[physical_port] = dom_info_dict
             if dom_info_dict is not None:
                 beautify_dom_info_dict(dom_info_dict, physical_port)
-                if 'rx5power' in dom_info_dict:
-                    fvs = swsscommon.FieldValuePairs(
-                        [('temperature', dom_info_dict['temperature']),
-                         ('voltage', dom_info_dict['voltage']),
-                         ('rx1power', dom_info_dict['rx1power']),
-                         ('rx2power', dom_info_dict['rx2power']),
-                         ('rx3power', dom_info_dict['rx3power']),
-                         ('rx4power', dom_info_dict['rx4power']),
-                         ('rx5power', dom_info_dict['rx5power']),
-                         ('rx6power', dom_info_dict['rx6power']),
-                         ('rx7power', dom_info_dict['rx7power']),
-                         ('rx8power', dom_info_dict['rx8power']),
-                         ('tx1bias', dom_info_dict['tx1bias']),
-                         ('tx2bias', dom_info_dict['tx2bias']),
-                         ('tx3bias', dom_info_dict['tx3bias']),
-                         ('tx4bias', dom_info_dict['tx4bias']),
-                         ('tx5bias', dom_info_dict['tx5bias']),
-                         ('tx6bias', dom_info_dict['tx6bias']),
-                         ('tx7bias', dom_info_dict['tx7bias']),
-                         ('tx8bias', dom_info_dict['tx8bias']),
-                         ('tx1power', dom_info_dict['tx1power']),
-                         ('tx2power', dom_info_dict['tx2power']),
-                         ('tx3power', dom_info_dict['tx3power']),
-                         ('tx4power', dom_info_dict['tx4power']),
-                         ('tx5power', dom_info_dict['tx5power']),
-                         ('tx6power', dom_info_dict['tx6power']),
-                         ('tx7power', dom_info_dict['tx7power']),
-                         ('tx8power', dom_info_dict['tx8power'])
-                         ])
-                else:
-                    fvs = swsscommon.FieldValuePairs(
-                        [('temperature', dom_info_dict['temperature']),
-                         ('voltage', dom_info_dict['voltage']),
-                         ('rx1power', dom_info_dict['rx1power']),
-                         ('rx2power', dom_info_dict['rx2power']),
-                         ('rx3power', dom_info_dict['rx3power']),
-                         ('rx4power', dom_info_dict['rx4power']),
-                         ('tx1bias', dom_info_dict['tx1bias']),
-                         ('tx2bias', dom_info_dict['tx2bias']),
-                         ('tx3bias', dom_info_dict['tx3bias']),
-                         ('tx4bias', dom_info_dict['tx4bias']),
-                         ('tx1power', dom_info_dict['tx1power']),
-                         ('tx2power', dom_info_dict['tx2power']),
-                         ('tx3power', dom_info_dict['tx3power']),
-                         ('tx4power', dom_info_dict['tx4power'])
-                         ])
-
+                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in dom_info_dict.items()])
                 table.set(port_name, fvs)
 
             else:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -495,7 +495,6 @@ def post_port_dom_info_to_db(logical_port_name, port_mapping, table, stop_event=
                 beautify_dom_info_dict(dom_info_dict, physical_port)
                 fvs = swsscommon.FieldValuePairs([(k, v) for k, v in dom_info_dict.items()])
                 table.set(port_name, fvs)
-
             else:
                 return SFP_EEPROM_NOT_READY
 


### PR DESCRIPTION
Add new fields (such as pdl, osnr, esnr, laser_config_freq, laser_curr_freq) to DOM_SENSOR table in STATE_DB for C_CMIS

> **Warning**
> Please don't merge. This PR is just for review purpose.

1. Not just the above mentioned fields(pdl, osnr, esnr, laser_config_freq, laser_curr_freq), all the fields that are supported by c_cmis [get_transceiver_bulk_status](https://github.com/sonic-net/sonic-platform-common/blob/b26aa5ef79fca95064d0baf3b1beed8d56d212f8/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py#L302) API but not currently present are added.
2. Existing code regarding processing of raw data and data filling of DB table is refactored.

Refer to this [doc](https://github.com/sonic-net/SONiC/blob/70e226778e9112e6e2bf666b1744687348cba303/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#212-transceiver-dom-sensor-table) for new DOM_SENSOR table, and this [doc](https://github.com/sonic-net/SONiC/blob/70e226778e9112e6e2bf666b1744687348cba303/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#212-transceiver-dom-sensor-table) for old DOM_SENSOR table.


UT:

1. new DB output for 400ZR (C_CMIS based):
```
127.0.0.1:6379[6]> hgetall "TRANSCEIVER_DOM_SENSOR|Ethernet6"
  1) "rx_los"
  2) "False"
  3) "tx_fault"
  4) "False"
  5) "tx_disabled_channel"
  6) "255"
  7) "temperature"
  8) "47.625"
  9) "voltage"
 10) "3.187"
 11) "tx1disable"
 12) "True"
 13) "tx1bias"
 14) "266.696"
 15) "rx1power"
 16) "-9.858996784803795"
 17) "tx1power"
 18) "-33.979400086720375"
 19) "tx2disable"
 20) "True"
 21) "tx2bias"
 22) "0.0"
 23) "rx2power"
 24) "-inf"
 25) "tx2power"
 26) "-inf"
 27) "tx3disable"
 28) "True"
 29) "tx3bias"
 30) "0.0"
 31) "rx3power"
 32) "-inf"
 33) "tx3power"
 34) "-inf"
 35) "tx4disable"
 36) "True"
 37) "tx4bias"
 38) "0.0"
 39) "rx4power"
 40) "-inf"
 41) "tx4power"
 42) "-inf"
 43) "tx5disable"
 44) "True"
 45) "tx5bias"
 46) "0.0"
 47) "rx5power"
 48) "-inf"
 49) "tx5power"
 50) "-inf"
 51) "tx6disable"
 52) "True"
 53) "tx6bias"
 54) "0.0"
 55) "rx6power"
 56) "-inf"
 57) "tx6power"
 58) "-inf"
 59) "tx7disable"
 60) "True"
 61) "tx7bias"
 62) "0.0"
 63) "rx7power"
 64) "-inf"
 65) "tx7power"
 66) "-inf"
 67) "tx8disable"
 68) "True"
 69) "tx8bias"
 70) "0.0"
 71) "rx8power"
 72) "-inf"
 73) "tx8power"
 74) "-inf"
 75) "laser_temperature"
 76) "39.92578125"
 77) "prefec_ber"
 78) "0.0"
 79) "postfec_ber"
 80) "0.0"
 81) "bias_xi"
 82) "69.08369573510338"
 83) "bias_xq"
 84) "58.309300373846035"
 85) "bias_xp"
 86) "54.216830701152055"
 87) "bias_yi"
 88) "52.37354085603113"
 89) "bias_yq"
 90) "44.88288700694285"
 91) "bias_yp"
 92) "64.86762798504616"
 93) "cd_shortlink"
 94) "0"
 95) "cd_longlink"
 96) "0"
 97) "dgd"
 98) "0.0"
 99) "pdl"
100) "0.0"
101) "osnr"
102) "0.0"
103) "esnr"
104) "0.0"
105) "cfo"
106) "0"
107) "tx_curr_power"
108) "-32.81"
109) "rx_tot_power"
110) "-9.58"
111) "laser_config_freq"
112) "193100"
113) "laser_curr_freq"
114) "193100.0"
115) "tx_config_power"
116) "-10.1"
......
```

2. For comparison, old DB output for 400ZR (C_CMIS):
```
127.0.0.1:6379[6]> hgetall "TRANSCEIVER_DOM_SENSOR|Ethernet6"
 1) "temperature"
 2) "47.648"
 3) "voltage"
 4) "3.19"
 5) "rx1power"
 6) "-9.9225222199926"
 7) "rx2power"
 8) "-inf"
 9) "rx3power"
10) "-inf"
11) "rx4power"
12) "-inf"
13) "rx5power"
14) "-inf"
15) "rx6power"
16) "-inf"
17) "rx7power"
18) "-inf"
19) "rx8power"
20) "-inf"
21) "tx1bias"
22) "266.696"
23) "tx2bias"
24) "0.0"
25) "tx3bias"
26) "0.0"
27) "tx4bias"
28) "0.0"
29) "tx5bias"
30) "0.0"
31) "tx6bias"
32) "0.0"
33) "tx7bias"
34) "0.0"
35) "tx8bias"
36) "0.0"
37) "tx1power"
38) "-10.10550182333308"
39) "tx2power"
40) "-inf"
41) "tx3power"
42) "-inf"
43) "tx4power"
44) "-inf"
45) "tx5power"
46) "-inf"
47) "tx6power"
48) "-inf"
49) "tx7power"
50) "-inf"
51) "tx8power"
52) "-inf"
....
```

3. new DB output for 400GBASE-DR4 (CMIS based)
```
1127.0.0.1:6379[6]> hgetall "TRANSCEIVER_DOM_SENSOR|Ethernet10"
  1) "rx_los"
  2) "False"
  3) "tx_fault"
  4) "N/A"
  5) "tx_disabled_channel"
  6) "0"
  7) "temperature"
  8) "48.137"
  9) "voltage"
 10) "3.248"
 11) "tx1disable"
 12) "False"
 13) "tx1bias"
 14) "75.0"
 15) "rx1power"
 16) "0.438336541331468"
 17) "tx1power"
 18) "1.2920635774752922"
 19) "tx2disable"
 20) "False"
 21) "tx2bias"
 22) "75.0"
 23) "rx2power"
 24) "0.5842602445700535"
 25) "tx2power"
 26) "0.6254438134646483"
 27) "tx3disable"
 28) "False"
 29) "tx3bias"
 30) "75.0"
 31) "rx3power"
 32) "0.49799277918986523"
 33) "tx3power"
 34) "1.0751522565146452"
 35) "tx4disable"
 36) "False"
 37) "tx4bias"
 38) "75.0"
 39) "rx4power"
 40) "0.25346834509827126"
 41) "tx4power"
 42) "0.9394672389058312"
 43) "tx5disable"
 44) "False"
 45) "tx5bias"
 46) "0.0"
 47) "rx5power"
 48) "-inf"
 49) "tx5power"
 50) "-inf"
 51) "tx6disable"
 52) "False"
 53) "tx6bias"
 54) "0.0"
 55) "rx6power"
 56) "-inf"
 57) "tx6power"
 58) "-inf"
 59) "tx7disable"
 60) "False"
 61) "tx7bias"
 62) "0.0"
 63) "rx7power"
 64) "-inf"
 65) "tx7power"
 66) "-inf"
 67) "tx8disable"
 68) "False"
 69) "tx8bias"
 70) "0.0"
 71) "rx8power"
 72) "-inf"
 73) "tx8power"
 74) "-inf"
 75) "laser_temperature"
 76) "60.01953125"
......
```

4. old DB output for 400GBASE-DR4 (CMIS)
```
127.0.0.1:6379[6]> hgetall "TRANSCEIVER_DOM_SENSOR|Ethernet10"
 1) "temperature"
 2) "40.535"
 3) "voltage"
 4) "3.249"
 5) "rx1power"
 6) "0.35109402944575496"
 7) "rx2power"
 8) "0.5576046468773478"
 9) "rx3power"
10) "0.4879127384840971"
11) "rx4power"
12) "0.35629827790438817"
13) "rx5power"
14) "-inf"
15) "rx6power"
16) "-inf"
17) "rx7power"
18) "-inf"
19) "rx8power"
20) "-inf"
21) "tx1bias"
22) "75.0"
23) "tx2bias"
24) "75.0"
25) "tx3bias"
26) "75.0"
27) "tx4bias"
28) "75.0"
29) "tx5bias"
30) "0.0"
31) "tx6bias"
32) "0.0"
33) "tx7bias"
34) "0.0"
35) "tx8bias"
36) "0.0"
37) "tx1power"
38) "1.2224865397805356"
39) "tx2power"
40) "0.6077336326170618"
41) "tx3power"
42) "1.0294796800537362"
43) "tx4power"
44) "0.9555289601940186"
45) "tx5power"
46) "-inf"
47) "tx6power"
48) "-inf"
49) "tx7power"
50) "-inf"
51) "tx8power"
52) "-inf"
......
```